### PR TITLE
Invalid manifest fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,8 @@
         "matches": [
           "*://*.testportal.pl/*",
           "*://*.testportal.net/*",
-          "://.teams.microsoft.com/",
-          "://.teams.testportal.net/"
+          "*://*.teams.microsoft.com/*",
+          "*://*.teams.testportal.net/*"
         ],
         "js": ["content.js"] 
         }],

--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,7 @@
         "matches": [
           "*://*.testportal.pl/*",
           "*://*.testportal.net/*",
-          "*://*.teams.microsoft.com/*",
-          "*://*.teams.testportal.net/*"
+          "*://*.teams.microsoft.com/*"
         ],
         "js": ["content.js"] 
         }],


### PR DESCRIPTION
Przeglądarka Opera wyrzuca wyjątek w linijce 10. "Invalid scheme". Zastosowałem pattern z poprzednich dwóch wpisów, aby na pewno lista działała.
Wywaliłem także jedną maskę, bo istniejąca jest w pełni wystarczająca.